### PR TITLE
fix ui

### DIFF
--- a/wb_front/src/app/pages/admin/settings/ui/components/TestQuestionsCard.tsx
+++ b/wb_front/src/app/pages/admin/settings/ui/components/TestQuestionsCard.tsx
@@ -373,7 +373,7 @@ export function TestQuestionsCard({
                                             />
 
                                             <select
-                                                className="rounded-md border bg-white px-3 py-2 text-sm"
+                                                className="w-full rounded-md border bg-white px-3 py-2 text-sm"
                                                 value={link.targetType}
                                                 onChange={(e) => {
                                                     const nextType = e.target.value as TestAnswerTargetType;
@@ -390,7 +390,7 @@ export function TestQuestionsCard({
 
                                             {link.targetType === "question" ? (
                                                 <select
-                                                    className="rounded-md border bg-white px-3 py-2 text-sm"
+                                                    className="w-full rounded-md border bg-white px-3 py-2 text-sm"
                                                     value={link.targetValue}
                                                     onChange={(e) =>
                                                         onUpdateAnswerLink(qIndex, oIndex, "question", e.target.value)
@@ -404,7 +404,7 @@ export function TestQuestionsCard({
                                                 </select>
                                             ) : (
                                                 <select
-                                                    className="rounded-md border bg-white px-3 py-2 text-sm"
+                                                    className="w-full rounded-md border bg-white px-3 py-2 text-sm"
                                                     value={link.targetValue}
                                                     onChange={(e) =>
                                                         onUpdateAnswerLink(qIndex, oIndex, "segment", e.target.value)

--- a/wb_front/src/app/pages/seller/actions/ui/components/ActionCard.tsx
+++ b/wb_front/src/app/pages/seller/actions/ui/components/ActionCard.tsx
@@ -41,7 +41,7 @@ export function ActionCard({ action, index, onSelect }: ActionCardProps) {
                         <span>{action.category}</span>
                     </div> */}
 
-                    {isActive && (
+                    {/* {isActive && (
                         <div className="grid grid-cols-2 gap-4 pt-2">
                             <div className="flex items-center gap-2">
                                 <Users className="w-4 h-4 text-muted-foreground" />
@@ -58,7 +58,7 @@ export function ActionCard({ action, index, onSelect }: ActionCardProps) {
                                 </div>
                             </div>
                         </div>
-                    )}
+                    )} */}
 
                     <Button className="w-full" disabled={isCompleted} onClick={() => onSelect(action.id)}>
                         {isCompleted ? "Акция завершена" : "Выбрать сегменты"}

--- a/wb_front/src/app/pages/seller/segments/ui/components/SegmentCard.tsx
+++ b/wb_front/src/app/pages/seller/segments/ui/components/SegmentCard.tsx
@@ -63,13 +63,13 @@ export function SegmentCard({ segment, index, onClick }: SegmentCardProps) {
 
                     {/* Статистика */}
                     <div className="grid grid-cols-2 gap-4 mb-4">
-                        <div className="flex items-center gap-2">
+                        {/* <div className="flex items-center gap-2">
                             <Users className="w-4 h-4 text-muted-foreground" />
                             <div>
                                 <div className="text-xs text-muted-foreground">Охват</div>
                                 <div className="font-semibold">{formatReach(segment.reach)}</div>
                             </div>
-                        </div>
+                        </div> */}
                         <div className="flex items-center gap-2">
                             <Package className="w-4 h-4 text-muted-foreground" />
                             <div>


### PR DESCRIPTION
<h3>PR Summary by Qodo</h3>

Fix seller/admin UI layout and hide incomplete stats blocks
<code>🐞 Bug fix</code> <code>✨ Enhancement</code> <code>🕐 10-20 Minutes</code>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>Walkthroughs</h3>

<details open>
<summary>Description</summary>

<br/>

<pre>
• Make select inputs full-width in admin test question linking UI.
• Hide conditional “active” details section in seller ActionCard.
• Hide “reach” statistic block in seller SegmentCard to reduce visual noise.
</pre>
</details>

<details>
<summary>Diagram</summary>

<br/>

```mermaid
graph TD
  AdminSettings["Admin Settings page"] --> TestQuestionsCard["TestQuestionsCard"] --> Selects["Select inputs (w-full)"]
  SellerActions["Seller Actions page"] --> ActionCard["ActionCard"] --> ActiveDetails["Active details (hidden)"]
  SellerSegments["Seller Segments page"] --> SegmentCard["SegmentCard"] --> ReachStat["Reach stat (hidden)"]
```

</details>




<details>
<summary>High-Level Assessment</summary>

<br/>

The following are alternative approaches to this PR:

<details>
<summary><b>1. Feature-flag or prop-driven visibility toggle</b></summary>

- ➕ Avoids long-lived commented code in components
- ➕ Makes it easy to re-enable per environment/user role
- ➖ Requires plumbing configuration/props through components
- ➖ Slightly more code than quick UI hide

</details>

<details>
<summary><b>2. Use CSS/utility class conditional rendering instead of commenting</b></summary>

- ➕ Keeps logic testable and avoids dead/commented code
- ➕ Enables responsive hiding without code removal
- ➖ Still leaves the DOM/logic around unless fully conditionally rendered
- ➖ May not match intent if the section should be removed entirely

</details>

**Recommendation:** For the width fix, the current Tailwind change is appropriate. For the hidden sections, prefer a prop/feature-flag (or explicit conditional render) over commented JSX if these blocks are expected to return; it reduces maintenance risk and makes intent clearer.

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>File Changes</h3>

<details>
<summary><strong>Enhancement</strong> (2)</summary>

<blockquote>
<details>
<summary><strong>ActionCard.tsx</strong> <code>Hide active-state details grid in ActionCard</code> <code>+2/-2</code></summary>

<br/>

>Hide active-state details grid in ActionCard
>
><pre>
>• Comments out the conditional &#x27;isActive&#x27; details section (the 2-column stats/grid block). Keeps the primary CTA button intact while removing extra details from the card UI.
></pre>
>
><a href='https://github.com/eugenesuv/wildberries/pull/56/files#diff-c66e7200c2f4cc4e5e42c095285dc28dfefbc2ffe90c27185c88f386cdb1f868'>wb_front/src/app/pages/seller/actions/ui/components/ActionCard.tsx</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>SegmentCard.tsx</strong> <code>Hide reach statistic block in SegmentCard</code> <code>+2/-2</code></summary>

<br/>

>Hide reach statistic block in SegmentCard
>
><pre>
>• Comments out the “Охват” (reach) statistic UI block within the stats grid. Leaves the remaining stats (e.g., items) visible.
></pre>
>
><a href='https://github.com/eugenesuv/wildberries/pull/56/files#diff-2fb87b49b4b5b513fce5bb233013e40022b0050bbec667887ebeec339168c9b4'>wb_front/src/app/pages/seller/segments/ui/components/SegmentCard.tsx</a>
<hr/>

</details>
</blockquote>

</details>

<details>
<summary><strong>Bug fix</strong> (1)</summary>

<blockquote>
<details>
<summary><strong>TestQuestionsCard.tsx</strong> <code>Make answer-target selects full width</code> <code>+3/-3</code></summary>

<br/>

>Make answer-target selects full width
>
><pre>
>• Adds the Tailwind &#x27;w-full&#x27; class to select inputs used to choose target type and target value. This improves alignment/spacing within the card by making selects fill the container width.
></pre>
>
><a href='https://github.com/eugenesuv/wildberries/pull/56/files#diff-7741b72e356bf6575d91055718990de12629a006b47027da4a05c1c42e7b3f45'>wb_front/src/app/pages/admin/settings/ui/components/TestQuestionsCard.tsx</a>
<hr/>

</details>
</blockquote>

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">


<a href="https://www.qodo.ai"><img src="https://www.qodo.ai/wp-content/uploads/2025/03/qodo-logo.svg" width="80" alt="Qodo Logo"></a>